### PR TITLE
Fix limited `_` character replacement

### DIFF
--- a/app/assets/javascripts/i18n.js
+++ b/app/assets/javascripts/i18n.js
@@ -669,7 +669,7 @@
       var s = scope.split('.').slice(-1)[0];
       //replace underscore with space && camelcase with space and lowercase letter
       return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') +
-          s.replace('_',' ').replace(/([a-z])([A-Z])/g,
+          s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g,
           function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
     }
 


### PR DESCRIPTION
Expression `s.replace('_',' ')` replaces just the first occurrence of underscore character. This fixes display o long strings before localisation is ready.